### PR TITLE
fix: make executable files PIE

### DIFF
--- a/compiler/driver/src/main.rs
+++ b/compiler/driver/src/main.rs
@@ -107,6 +107,7 @@ fn emit_object_file_to_tempfile(bitcode_path: &Path) -> anyhow::Result<TempPath>
 fn emit_exe_file(obj_path: &Path, output_file_path: &Path) -> anyhow::Result<()> {
     let status = Command::new("cc")
         .args([
+            OsStr::new("-fPIE"), // Enable position-independent executable
             OsStr::new("-o"),
             output_file_path.as_os_str(),
             obj_path.as_os_str(),

--- a/compiler/driver/tests/leak.rs
+++ b/compiler/driver/tests/leak.rs
@@ -3,8 +3,6 @@ use assert_fs::prelude::*;
 use predicates::prelude::*;
 use std::process::Command;
 
-const KAEDE_GC_LIB_PATH: &str = concat!(env!("HOME"), "/.kaede/lib/libkgc.so");
-
 #[test]
 fn leak_check_with_valgrind() -> anyhow::Result<()> {
     // Create a temporary directory for all files
@@ -39,39 +37,16 @@ fn leak_check_with_valgrind() -> anyhow::Result<()> {
         }",
     )?;
 
-    // Compile
-    let compile_output = Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
+    // Compile to executable directly
+    let executable = temp_dir.child("leak");
+    Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
         .args([
             "-O0",
-            "--display-llvm-ir",
+            "-o",
+            &executable.path().to_string_lossy(),
             "--root-dir",
             &temp_dir.path().to_string_lossy(),
             &program_file.path().to_string_lossy(),
-        ])
-        .assert()
-        .success();
-
-    let llvm_ir = temp_dir.child("leak.ll");
-    llvm_ir.write_binary(&compile_output.get_output().stdout)?;
-
-    let asm = temp_dir.child("leak.s");
-    asm.write_binary(
-        &Command::new("llc")
-            .args([&llvm_ir.path().to_string_lossy(), "-o", "-"])
-            .assert()
-            .success()
-            .get_output()
-            .stdout,
-    )?;
-
-    let executable = temp_dir.child("leak");
-    Command::new("cc")
-        .args([
-            "-g",
-            &asm.path().to_string_lossy(),
-            KAEDE_GC_LIB_PATH,
-            "-o",
-            &executable.path().to_string_lossy(),
         ])
         .assert()
         .success();


### PR DESCRIPTION
And refactor memory leak tests

- 出力される実行ファイルを位置独立コード（PIE）にする