### PR TITLE
test: add failing case for memory leak test with --no-gc

### DIFF
--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -52,7 +52,7 @@ fn jit_compile(module: &Module) -> anyhow::Result<i32> {
 /// Return exit status
 fn exec(program: &str) -> anyhow::Result<i32> {
     let context = Context::create();
-    let cgcx = CodegenCtx::new(&context).unwrap();
+    let cgcx = CodegenCtx::new(&context, false).unwrap();
 
     let file = PathBuf::from("test").into();
 

--- a/compiler/driver/src/main.rs
+++ b/compiler/driver/src/main.rs
@@ -55,6 +55,9 @@ struct Args {
 
     #[arg(long, action)]
     no_prelude: bool,
+
+    #[arg(long, action)]
+    no_gc: bool,
 }
 
 fn to_inkwell_opt_level(level: u8) -> OptimizationLevel {
@@ -219,7 +222,7 @@ fn compile_and_output_obj(
     option: CompileOption,
 ) -> anyhow::Result<()> {
     let context = Context::create();
-    let cgcx = CodegenCtx::new(&context)?;
+    let cgcx = CodegenCtx::new(&context, option.no_gc)?;
 
     let root_dir = option.root_dir.unwrap_or(PathBuf::from("."));
 
@@ -245,7 +248,7 @@ fn compile_and_output_obj(
 
 fn compile_and_link(unit_infos: Vec<CompileUnitInfo>, option: CompileOption) -> anyhow::Result<()> {
     let context = Context::create();
-    let cgcx = CodegenCtx::new(&context)?;
+    let cgcx = CodegenCtx::new(&context, option.no_gc)?;
 
     let root_dir = option.root_dir.unwrap_or(PathBuf::from("."));
 
@@ -280,6 +283,7 @@ struct CompileOption {
     root_dir: Option<PathBuf>,
     no_autoload: bool,
     no_prelude: bool,
+    no_gc: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -300,6 +304,7 @@ fn main() -> anyhow::Result<()> {
         root_dir: args.root_dir,
         no_autoload: args.no_autoload,
         no_prelude: args.no_prelude,
+        no_gc: args.no_gc,
     };
 
     if let Some(program) = args.program {

--- a/compiler/driver/tests/leak.rs
+++ b/compiler/driver/tests/leak.rs
@@ -3,89 +3,113 @@ use assert_fs::prelude::*;
 use predicates::prelude::*;
 use std::process::Command;
 
-const KAEDE_GC_LIB_PATH: &str = concat!(env!("HOME"), "/.kaede/lib/libkgc.so");
+/// Test program that allocates memory in a loop to test garbage collection
+const TEST_PROGRAM: &str = r"struct Num {
+    n: i32,
+}
 
-#[test]
-fn leak_check_with_valgrind() -> anyhow::Result<()> {
-    // Create a temporary directory for all files
+fn f(): ([i32; 3], (i32, i32, Num)) {
+    let a = [1, 2, 3]
+    let t = (48, 10, Num { n: 58 })
+    return (a, t)
+}
+
+fn main(): i32 {
+    let mut c = 0
+
+    loop {
+        let num = Num { n: 58 }
+
+        if c == 1000 {
+            return num.n
+        }
+
+        c = c + 1
+    }
+
+    return 123
+}";
+
+/// Helper function to set up the test environment and create the program file
+fn setup_test_environment() -> anyhow::Result<(
+    assert_fs::TempDir,
+    impl AsRef<std::path::Path>,
+    impl AsRef<std::path::Path>,
+)> {
     let temp_dir = assert_fs::TempDir::new()?;
-
     let program_file = temp_dir.child("leak.kd");
-    program_file.write_str(
-        r"struct Num {
-            n: i32,
-        }
-
-        fn f(): ([i32; 3], (i32, i32, Num)) {
-            let a = [1, 2, 3]
-            let t = (48, 10, Num { n: 58 })
-            return (a, t)
-        }
-
-        fn main(): i32 {
-            let mut c = 0
-
-            loop {
-                let num = Num { n: 58 }
-
-                if c == 1000 {
-                    return num.n
-                }
-
-                c = c + 1
-            }
-
-            return 123
-        }",
-    )?;
-
-    // Compile
-    let compile_output = Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
-        .args([
-            "-O0",
-            "--display-llvm-ir",
-            "--root-dir",
-            &temp_dir.path().to_string_lossy(),
-            &program_file.path().to_string_lossy(),
-        ])
-        .assert()
-        .success();
-
-    let llvm_ir = temp_dir.child("leak.ll");
-    llvm_ir.write_binary(&compile_output.get_output().stdout)?;
-
-    let asm = temp_dir.child("leak.s");
-    asm.write_binary(
-        &Command::new("llc")
-            .args([&llvm_ir.path().to_string_lossy(), "-o", "-"])
-            .assert()
-            .success()
-            .get_output()
-            .stdout,
-    )?;
-
     let executable = temp_dir.child("leak");
-    Command::new("cc")
-        .args([
-            "-g",
-            &asm.path().to_string_lossy(),
-            KAEDE_GC_LIB_PATH,
-            "-o",
-            &executable.path().to_string_lossy(),
-        ])
+
+    program_file.write_str(TEST_PROGRAM)?;
+
+    Ok((temp_dir, program_file, executable))
+}
+
+/// Helper function to compile the program with given compiler arguments
+fn compile_program(
+    program_file: &impl AsRef<std::path::Path>,
+    executable: &impl AsRef<std::path::Path>,
+    temp_dir: &assert_fs::TempDir,
+    extra_args: &[&str],
+) -> anyhow::Result<()> {
+    let executable_path = executable.as_ref().to_string_lossy();
+    let temp_dir_path = temp_dir.path().to_string_lossy();
+    let program_file_path = program_file.as_ref().to_string_lossy();
+
+    let mut args = vec![
+        "-O0",
+        "-o",
+        executable_path.as_ref(),
+        "--root-dir",
+        temp_dir_path.as_ref(),
+    ];
+    args.extend_from_slice(extra_args);
+    args.push(program_file_path.as_ref());
+
+    Command::cargo_bin(env!("CARGO_BIN_EXE_kaede"))?
+        .args(args)
         .assert()
         .success();
 
-    // Leak check
-    Command::new("valgrind")
-        .args(["--leak-check=full", &executable.path().to_string_lossy()])
+    Ok(())
+}
+
+/// Helper function to run valgrind and check for leaks
+fn run_valgrind_leak_check(executable: &impl AsRef<std::path::Path>, should_have_leaks: bool) {
+    let executable_path = executable.as_ref().to_string_lossy();
+    let assertion = Command::new("valgrind")
+        .args(["--leak-check=full", executable_path.as_ref()])
         .assert()
-        .code(predicate::eq(58))
-        .stderr(
+        .code(predicate::eq(58));
+
+    if should_have_leaks {
+        // Expect memory leaks when GC is disabled
+        assertion.stderr(
+            predicate::str::contains("definitely lost")
+                .and(predicate::str::contains("definitely lost: 0").not()),
+        );
+    } else {
+        // Expect no memory leaks when GC is enabled
+        assertion.stderr(
             // Valgrind results display changes depending on version
             predicate::str::contains("definitely lost: 0")
                 .or(predicate::str::contains("definitely lost").count(0)),
         );
+    }
+}
 
+#[test]
+fn leak_check_with_valgrind() -> anyhow::Result<()> {
+    let (temp_dir, program_file, executable) = setup_test_environment()?;
+    compile_program(&program_file, &executable, &temp_dir, &[])?;
+    run_valgrind_leak_check(&executable, false);
+    Ok(())
+}
+
+#[test]
+fn leak_check_with_no_gc_should_fail() -> anyhow::Result<()> {
+    let (temp_dir, program_file, executable) = setup_test_environment()?;
+    compile_program(&program_file, &executable, &temp_dir, &["--no-gc"])?;
+    run_valgrind_leak_check(&executable, true);
     Ok(())
 }


### PR DESCRIPTION
- Add leak_check_with_no_gc_should_fail test that expects memory leaks when GC is disabled
- Extract common test setup and compilation logic into helper functions to reduce duplication
- Improve code formatting and fix lifetime issues

The new test verifies that memory leaks are properly detected when garbage collection is disabled.

- https://github.com/itto-hiramoto/kaede/issues/35