### PR TITLE
fix: Correct library linking order to resolve GC_malloc reference

### DIFF
--- a/compiler/driver/src/main.rs
+++ b/compiler/driver/src/main.rs
@@ -114,8 +114,8 @@ fn emit_exe_file(obj_path: &Path, output_file_path: &Path) -> anyhow::Result<()>
             OsStr::new("-o"),
             output_file_path.as_os_str(),
             obj_path.as_os_str(),
-            kaede_gc_lib_path().as_os_str(), // Link with garbage collector
-            kaede_lib_path().as_os_str(),    // Link with standard library
+            kaede_lib_path().as_os_str(), // Link with standard library first
+            kaede_gc_lib_path().as_os_str(), // Then link with garbage collector
         ])
         .status()?;
 


### PR DESCRIPTION
Fixed linking order in emit_exe_file function:
- Link standard library (libkd.so) first
- Link GC library (libgc.so) after, as libkd.so depends on it

This resolves "undefined reference to GC_malloc" error by ensuring the linker can properly resolve dependencies between libraries.