### PR TITLE
feat(editors): implement the Kaede TextMate grammar

### DIFF
--- a/.github/workflows/ci-nix-linux.yml
+++ b/.github/workflows/ci-nix-linux.yml
@@ -1,10 +1,17 @@
 name: CI (Linux)
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-linux-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check-and-test:
-    name: Check and test (Nix)
+    name: Check and test (Linux)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci-nix-macos.yml
+++ b/.github/workflows/ci-nix-macos.yml
@@ -1,10 +1,17 @@
 name: CI (macOS)
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-macos-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check-and-test:
-    name: Check and test (Nix)
+    name: Check and test (macOS)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci-vscode-extension.yml
+++ b/.github/workflows/ci-vscode-extension.yml
@@ -1,0 +1,48 @@
+name: CI (VS Code extension)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "editors/vscode/**"
+      - ".github/workflows/ci-vscode-extension.yml"
+  pull_request:
+    paths:
+      - "editors/vscode/**"
+      - ".github/workflows/ci-vscode-extension.yml"
+
+concurrency:
+  group: ci-vscode-extension-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  grammar-and-compile:
+    name: Grammar tests and TypeScript compile
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: editors/vscode
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: editors/vscode/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check every test file carries assertions
+        run: |
+          shopt -s globstar nullglob
+          for f in tests/**/*.kd; do
+            grep -qE '^//\s*(\^+|<-+)' "$f" || { echo "::error file=editors/vscode/$f::no scope assertions"; exit 1; }
+          done
+
+      - name: Run grammar tests
+        run: npm test
+
+      - name: Compile extension
+        run: npm run compile

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,1 +1,32 @@
 # Kaede Language Support (VS Code)
+
+Syntax highlighting and language-server integration for [Kaede](https://github.com/itto-hiramoto/kaede).
+
+## Layout
+
+- `syntaxes/kaede.tmLanguage.json` — TextMate grammar. Covers only what is decidable
+  lexically; anything needing name resolution is left to LSP semantic tokens, which
+  the Kaede language server does not implement yet. The grammar is the only
+  highlighting layer today.
+- `src/extension.ts` — launches `kaede lsp` over stdio.
+- `tests/` — scope assertions run by
+  [`vscode-tmgrammar-test`](https://github.com/PanAeon/vscode-tmgrammar-test). Each
+  non-obvious rule has a fixture whose comment names the hazard it guards against.
+  Fixtures are tokenized, never compiled, and several deliberately do not compile.
+
+## Development
+
+```bash
+npm install
+npm test           # grammar scope assertions
+npm run compile    # tsc
+```
+
+## Gotchas
+
+- Do not add `|$` to the `end` of a string rule. Kaede strings may span physical
+  lines, so the newline guard would break legal code. The cost is that an
+  unterminated string inverts quote parity for the rest of the file — string bodies
+  highlight as code and code as string — with no way to recover. `char` and
+  `byte-char` do carry the guard, because a char literal holds exactly one character
+  or escape and so can never span a line.

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -13,7 +13,8 @@
       "devDependencies": {
         "@types/node": "^26.2.0",
         "@types/vscode": "^1.125.0",
-        "typescript": "^7.0.2"
+        "typescript": "^7.0.2",
+        "vscode-tmgrammar-test": "^0.1.3"
       },
       "engines": {
         "vscode": "^1.78.0"
@@ -354,6 +355,19 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -361,6 +375,13 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.9",
@@ -372,6 +393,164 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "10.2.6",
@@ -387,6 +566,26 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -396,6 +595,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/typescript": {
@@ -478,6 +690,47 @@
       "version": "3.18.0",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
       "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g=="
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-textmate": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-7.0.4.tgz",
+      "integrity": "sha512-9hJp0xL7HW1Q5OgGe03NACo7yiCTMEk3WU/rtKXUbncLtdg6rVVNJnHwD88UhbIYU2KoxY0Dih0x+kIsmUKn2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-tmgrammar-test": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/vscode-tmgrammar-test/-/vscode-tmgrammar-test-0.1.3.tgz",
+      "integrity": "sha512-Wg6Pz+ePAT1O+F/A1Fc4wS5vY2X+HNtgN4qMdL+65NLQYd1/zdDWH4fhwsLjX8wTzeXkMy49Cr4ZqWTJ7VnVxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bottleneck": "^2.19.5",
+        "chalk": "^2.4.2",
+        "commander": "^9.2.0",
+        "diff": "^4.0.2",
+        "glob": "^7.1.6",
+        "vscode-oniguruma": "^1.5.1",
+        "vscode-textmate": "^7.0.1"
+      },
+      "bin": {
+        "vscode-tmgrammar-snap": "dist/snapshot.js",
+        "vscode-tmgrammar-test": "dist/unit.js"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     }
   },
   "dependencies": {
@@ -636,10 +889,25 @@
       "dev": true,
       "optional": true
     },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
     "balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
+    },
+    "bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true
     },
     "brace-expansion": {
       "version": "5.0.9",
@@ -649,6 +917,125 @@
         "balanced-match": "^4.0.2"
       }
     },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.18",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+          "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
     "minimatch": {
       "version": "10.2.6",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
@@ -657,10 +1044,34 @@
         "brace-expansion": "^5.0.8"
       }
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
+    },
     "semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
     },
     "typescript": {
       "version": "7.0.2",
@@ -730,6 +1141,39 @@
       "version": "3.18.0",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
       "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g=="
+    },
+    "vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-7.0.4.tgz",
+      "integrity": "sha512-9hJp0xL7HW1Q5OgGe03NACo7yiCTMEk3WU/rtKXUbncLtdg6rVVNJnHwD88UhbIYU2KoxY0Dih0x+kIsmUKn2A==",
+      "dev": true
+    },
+    "vscode-tmgrammar-test": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/vscode-tmgrammar-test/-/vscode-tmgrammar-test-0.1.3.tgz",
+      "integrity": "sha512-Wg6Pz+ePAT1O+F/A1Fc4wS5vY2X+HNtgN4qMdL+65NLQYd1/zdDWH4fhwsLjX8wTzeXkMy49Cr4ZqWTJ7VnVxg==",
+      "dev": true,
+      "requires": {
+        "bottleneck": "^2.19.5",
+        "chalk": "^2.4.2",
+        "commander": "^9.2.0",
+        "diff": "^4.0.2",
+        "glob": "^7.1.6",
+        "vscode-oniguruma": "^1.5.1",
+        "vscode-textmate": "^7.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     }
   }
 }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -35,7 +35,8 @@
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./"
+    "watch": "tsc -watch -p ./",
+    "test": "vscode-tmgrammar-test -g syntaxes/kaede.tmLanguage.json 'tests/**/*.kd'"
   },
   "dependencies": {
     "vscode-languageclient": "^10.1.0"
@@ -43,6 +44,7 @@
   "devDependencies": {
     "@types/node": "^26.2.0",
     "@types/vscode": "^1.125.0",
-    "typescript": "^7.0.2"
+    "typescript": "^7.0.2",
+    "vscode-tmgrammar-test": "^0.1.3"
   }
 }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -24,7 +24,9 @@ export function activate(context: vscode.ExtensionContext): void {
     transport: TransportKind.stdio
   };
 
-  const outputChannel = vscode.window.createOutputChannel("Kaede LSP");
+  const outputChannel = vscode.window.createOutputChannel("Kaede LSP", {
+    log: true
+  });
   const clientOptions: LanguageClientOptions = {
     documentSelector: [{ language: "kaede", scheme: "file" }],
     outputChannel,

--- a/editors/vscode/syntaxes/kaede.tmLanguage.json
+++ b/editors/vscode/syntaxes/kaede.tmLanguage.json
@@ -2,9 +2,352 @@
   "name": "Kaede",
   "scopeName": "source.kaede",
   "fileTypes": ["kd"],
-  "patterns": [
-    {
-      "include": "source.rust"
+  "patterns": [{ "include": "#main" }],
+  "repository": {
+    "main": {
+      "patterns": [
+        { "include": "#comments" },
+        { "include": "#byte-string" },
+        { "include": "#byte-char" },
+        { "include": "#interpolated-string" },
+        { "include": "#string" },
+        { "include": "#char" },
+        { "include": "#numbers" },
+        { "include": "#function-definition" },
+        { "include": "#type-definition" },
+        { "include": "#keywords" },
+        { "include": "#named-argument" },
+        { "include": "#function-call" },
+        { "include": "#fundamental-types" },
+        { "include": "#constant-caps" },
+        { "include": "#type-name" },
+        { "include": "#operators" },
+        { "include": "#punctuation" },
+        { "include": "#variable" }
+      ]
+    },
+
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.double-slash.kaede",
+          "match": "//.*"
+        },
+        { "include": "#block-comment" }
+      ]
+    },
+
+    "block-comment": {
+      "name": "comment.block.kaede",
+      "begin": "/\\*",
+      "end": "\\*/",
+      "patterns": [{ "include": "#block-comment" }]
+    },
+
+    "string-escapes": {
+      "patterns": [
+        {
+          "name": "constant.character.escape.kaede",
+          "match": "\\\\[nrt0\\\\\"']"
+        },
+        {
+          "name": "invalid.illegal.unknown-escape.kaede",
+          "match": "\\\\."
+        }
+      ]
+    },
+
+    "string": {
+      "name": "string.quoted.double.kaede",
+      "begin": "\"",
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.string.begin.kaede" }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.string.end.kaede" }
+      },
+      "patterns": [{ "include": "#string-escapes" }]
+    },
+
+    "char": {
+      "name": "string.quoted.single.kaede",
+      "begin": "'",
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.string.begin.kaede" }
+      },
+      "end": "'|$",
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.string.end.kaede" }
+      },
+      "patterns": [{ "include": "#string-escapes" }]
+    },
+
+    "byte-string": {
+      "name": "string.quoted.double.byte.kaede",
+      "begin": "(?<!\\p{XID_Continue})b\"",
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.string.begin.kaede" }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.string.end.kaede" }
+      },
+      "patterns": [{ "include": "#string-escapes" }]
+    },
+
+    "byte-char": {
+      "name": "string.quoted.single.byte.kaede",
+      "begin": "(?<!\\p{XID_Continue})b'",
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.string.begin.kaede" }
+      },
+      "end": "'|$",
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.string.end.kaede" }
+      },
+      "patterns": [{ "include": "#string-escapes" }]
+    },
+
+    "interpolated-string": {
+      "name": "string.quoted.double.interpolated.kaede",
+      "begin": "\\$[ \\t]*\"",
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.string.begin.kaede" }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.string.end.kaede" }
+      },
+      "patterns": [
+        {
+          "name": "constant.character.escape.kaede",
+          "match": "\\{\\{|\\}\\}"
+        },
+        { "include": "#interpolation" },
+        { "include": "#string-escapes" }
+      ]
+    },
+
+    "interpolation": {
+      "name": "meta.interpolation.kaede",
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": { "name": "punctuation.section.embedded.begin.kaede" }
+      },
+      "end": "\\}|(?=\")",
+      "endCaptures": {
+        "0": { "name": "punctuation.section.embedded.end.kaede" }
+      },
+      "patterns": [{ "include": "#interpolation-content" }]
+    },
+
+    "interpolation-content": {
+      "patterns": [
+        { "include": "#interpolation-nested-string" },
+        { "include": "#interpolation-braces" },
+        { "include": "#numbers" },
+        { "include": "#keywords" },
+        { "include": "#named-argument" },
+        { "include": "#function-call" },
+        { "include": "#fundamental-types" },
+        { "include": "#operators" },
+        { "include": "#punctuation" },
+        { "include": "#constant-caps" },
+        { "include": "#type-name" },
+        { "include": "#variable" }
+      ]
+    },
+
+    "interpolation-nested-string": {
+      "name": "string.quoted.double.kaede",
+      "begin": "\\\\\"",
+      "end": "\\\\\"|(?=\")",
+      "patterns": [
+        {
+          "name": "constant.character.escape.kaede",
+          "match": "\\\\\\\\."
+        }
+      ]
+    },
+
+    "interpolation-braces": {
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": { "name": "punctuation.brackets.curly.kaede" }
+      },
+      "end": "\\}|(?=\")",
+      "endCaptures": {
+        "0": { "name": "punctuation.brackets.curly.kaede" }
+      },
+      "patterns": [{ "include": "#interpolation-content" }]
+    },
+
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.integer.kaede",
+          "match": "(?<!\\p{XID_Continue})0[xX][0-9a-fA-F]+"
+        },
+        {
+          "name": "constant.numeric.float.kaede",
+          "match": "(?<!\\.\\s*)(?<!\\p{XID_Continue})[0-9]+\\.[0-9]+"
+        },
+        {
+          "name": "constant.numeric.integer.kaede",
+          "match": "(?<!\\p{XID_Continue})[0-9]+"
+        }
+      ]
+    },
+
+    "function-definition": {
+      "match": "((?<!\\p{XID_Continue})fun)[ \\t]+([\\p{XID_Start}_][\\p{XID_Continue}]*)",
+      "captures": {
+        "1": { "name": "storage.type.kaede" },
+        "2": { "name": "entity.name.function.kaede" }
+      }
+    },
+
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.kaede",
+          "match": "(?<!\\p{XID_Continue})(?:if|else|loop|while|break|return|match)(?!\\p{XID_Continue})"
+        },
+        {
+          "name": "keyword.control.concurrency.kaede",
+          "match": "(?<!\\p{XID_Continue})(?:spawn|select|case|default)(?!\\p{XID_Continue})"
+        },
+        {
+          "name": "keyword.control.import.kaede",
+          "match": "(?<!\\p{XID_Continue})(?:import|use)(?!\\p{XID_Continue})"
+        },
+        {
+          "name": "keyword.control.as.kaede",
+          "match": "(?<!\\p{XID_Continue})as(?!\\p{XID_Continue})"
+        },
+        {
+          "name": "storage.type.kaede",
+          "match": "(?<!\\p{XID_Continue})(?:fun|let|struct|enum|interface|impl|type)(?!\\p{XID_Continue})"
+        },
+        {
+          "name": "storage.modifier.kaede",
+          "match": "(?<!\\p{XID_Continue})(?:mut|export|const|extern)(?!\\p{XID_Continue})"
+        },
+        {
+          "name": "constant.language.boolean.kaede",
+          "match": "(?<!\\p{XID_Continue})(?:true|false)(?!\\p{XID_Continue})"
+        },
+        {
+          "name": "variable.language.self.kaede",
+          "match": "(?<!\\p{XID_Continue})self(?!\\p{XID_Continue})"
+        }
+      ]
+    },
+
+    "named-argument": {
+      "match": "(?<=[(,])[ \\t]*([\\p{XID_Start}_][\\p{XID_Continue}]*)[ \\t]*(=)(?!=)",
+      "captures": {
+        "1": { "name": "variable.parameter.kaede" },
+        "2": { "name": "keyword.operator.kaede" }
+      }
+    },
+
+    "fundamental-types": {
+      "name": "support.type.primitive.kaede",
+      "match": "(?<![.\\p{XID_Continue}])(?:i8|u8|i16|u16|i32|u32|i64|u64|f32|f64|char|bool|str)(?!\\p{XID_Continue})(?!\\.)"
+    },
+
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.arrow.kaede",
+          "match": "=>|->|<-"
+        },
+        {
+          "name": "keyword.operator.namespace.kaede",
+          "match": "::"
+        },
+        {
+          "name": "keyword.operator.variadic.kaede",
+          "match": "\\.\\.\\."
+        },
+        {
+          "name": "keyword.operator.bitwise.kaede",
+          "match": "<<|>>"
+        },
+        {
+          "name": "keyword.operator.comparison.kaede",
+          "match": "==|!=|<=|>="
+        },
+        {
+          "name": "keyword.operator.logical.kaede",
+          "match": "&&|\\|\\|"
+        },
+        {
+          "name": "keyword.operator.assignment.kaede",
+          "match": ":=|\\+=|-=|\\*=|/=|%=|="
+        },
+        {
+          "name": "keyword.operator.kaede",
+          "match": "\\.\\.|[+\\-*/%!&|^~?.:<>]"
+        }
+      ]
+    },
+
+    "punctuation": {
+      "patterns": [
+        {
+          "name": "punctuation.brackets.round.kaede",
+          "match": "[()]"
+        },
+        {
+          "name": "punctuation.brackets.curly.kaede",
+          "match": "[{}]"
+        },
+        {
+          "name": "punctuation.brackets.square.kaede",
+          "match": "[\\[\\]]"
+        },
+        {
+          "name": "punctuation.separator.kaede",
+          "match": ","
+        },
+        {
+          "name": "punctuation.terminator.kaede",
+          "match": ";"
+        }
+      ]
+    },
+
+    "type-definition": {
+      "match": "((?<!\\p{XID_Continue})(?:struct|enum|interface|type))(?!\\p{XID_Continue})[ \\t]+([\\p{XID_Start}_][\\p{XID_Continue}]*)",
+      "captures": {
+        "1": { "name": "storage.type.kaede" },
+        "2": { "name": "entity.name.type.kaede" }
+      }
+    },
+
+    "type-name": {
+      "name": "entity.name.type.kaede",
+      "match": "(?<!\\p{XID_Continue})\\p{Lu}[\\p{XID_Continue}]*(?!\\p{XID_Continue})"
+    },
+
+    "function-call": {
+      "match": "([\\p{XID_Start}_][\\p{XID_Continue}]*)(?=\\()",
+      "captures": {
+        "1": { "name": "entity.name.function.kaede" }
+      }
+    },
+
+    "variable": {
+      "name": "variable.other.kaede",
+      "match": "(?<!\\p{XID_Continue})[\\p{Ll}_][\\p{XID_Continue}]*(?!\\p{XID_Continue})"
+    },
+
+    "constant-caps": {
+      "name": "constant.other.caps.kaede",
+      "match": "(?<!\\p{XID_Continue})\\p{Lu}{2}[\\p{Lu}0-9_]*(?!\\p{XID_Continue})"
     }
-  ]
+  }
 }

--- a/editors/vscode/tests/comments.kd
+++ b/editors/vscode/tests/comments.kd
@@ -1,0 +1,26 @@
+// SYNTAX TEST "source.kaede" "line and nested block comments"
+
+// a line comment
+// <- comment.line.double-slash.kaede
+/* /* nested */ still a comment */
+// <- comment.block.kaede
+//    ^^^^^^ comment.block.kaede
+//              ^^^^^^^^^^^^^^^ comment.block.kaede
+let after_nested = 1
+// <- storage.type.kaede
+
+// a // inside a block comment must not swallow the terminator
+/* x // */ let after_slashes = 1
+//         ^^^ storage.type.kaede
+//             ^^^^^^^^^^^^^ - comment.block.kaede
+
+// a quote inside a block comment must not open a string
+/* he said "no */ let after_quote = 1
+//                ^^^ storage.type.kaede
+
+// a block comment opener inside a line comment is inert: /*
+let after_line = 1
+// <- storage.type.kaede
+
+let s = "// not a comment"
+//       ^^^^^^^^^^^^^^^^ string.quoted.double.kaede

--- a/editors/vscode/tests/escapes.kd
+++ b/editors/vscode/tests/escapes.kd
@@ -1,0 +1,15 @@
+// SYNTAX TEST "source.kaede" "the full escape set"
+
+let s = "\r\0\\\'"
+//       ^^ constant.character.escape.kaede
+//         ^^ constant.character.escape.kaede
+//            ^^ constant.character.escape.kaede
+
+let c = '\0'
+//       ^^ constant.character.escape.kaede
+
+// a doubled backslash before the closing quote does not escape it
+let t = "a\\"
+//        ^^ constant.character.escape.kaede
+let after_backslash = 1
+// <- storage.type.kaede

--- a/editors/vscode/tests/guards.kd
+++ b/editors/vscode/tests/guards.kd
@@ -1,0 +1,28 @@
+// SYNTAX TEST "source.kaede" "negative guards that prevent over-matching"
+
+// a path segment named like a primitive is not a primitive
+import std.str.something
+//         ^^^ - support.type.primitive.kaede
+use autoload.char.Char
+//           ^^^^ - support.type.primitive.kaede
+
+// a comparison inside a call is not a named argument
+f(a == b)
+//^ - variable.parameter.kaede
+g(x, y == z)
+//   ^ - variable.parameter.kaede
+
+// a b glued to an identifier does not start a byte char
+let ab = ab'x'
+//       ^^ - string.quoted.single.byte.kaede
+//         ^^^ string.quoted.single.kaede
+
+// hex digits inside an identifier are not a hex literal
+let v0x10 = 1
+//  ^^^^^ - constant.numeric.integer.kaede
+
+// a tuple index after an identifier ending in a digit is not a float
+let t = tup1.0
+//      ^^^^ - constant.numeric.float.kaede
+//           ^ constant.numeric.integer.kaede
+

--- a/editors/vscode/tests/identifiers.kd
+++ b/editors/vscode/tests/identifiers.kd
@@ -1,0 +1,18 @@
+// SYNTAX TEST "source.kaede" "unicode XID identifiers"
+
+fun __sys_read(fd: i32) -> i32 { return 0 }
+//  ^^^^^^^^^^ entity.name.function.kaede
+fun 日本語_x1() -> i32 { return 0 }
+//  ^^^^^^ entity.name.function.kaede
+
+// keywords and type names must not match inside identifiers
+let iffy = 1
+//  ^^^^ - keyword.control.kaede
+let _self = 1
+//  ^^^^^ - variable.language.self.kaede
+let selfish = 1
+//  ^^^^^^^ - variable.language.self.kaede
+let strand = 1
+//  ^^^^^^ - support.type.primitive.kaede
+let funny = 1
+//  ^^^^^ - entity.name.function.kaede

--- a/editors/vscode/tests/interp_body.kd
+++ b/editors/vscode/tests/interp_body.kd
@@ -1,0 +1,31 @@
+// SYNTAX TEST "source.kaede" "interpolation body sub-rules"
+
+println($"{1 + 2}")
+//         ^ constant.numeric.integer.kaede
+//           ^ keyword.operator.kaede
+//             ^ constant.numeric.integer.kaede
+
+println($"{n as u8}")
+//           ^^ keyword.control.as.kaede
+//              ^^ support.type.primitive.kaede
+
+// two levels of brace nesting inside one interpolation
+println($"{if a { if b { 1 } else { 2 } } else { 3 }}")
+//                       ^ constant.numeric.integer.kaede
+//                           ^^^^ keyword.control.kaede
+//                                  ^ constant.numeric.integer.kaede
+//                                               ^ constant.numeric.integer.kaede
+let after_deep = 1
+// <- storage.type.kaede
+
+// an escape inside a nested string inside an interpolation
+println($"{f(\"a\\nb\")}")
+//              ^^^ constant.character.escape.kaede
+let after_nested_escape = 1
+// <- storage.type.kaede
+
+// a struct literal inside an interpolation
+println($"{Foo { x: 1 }}")
+//                  ^ constant.numeric.integer.kaede
+let after_struct_lit = 1
+// <- storage.type.kaede

--- a/editors/vscode/tests/interpolation.kd
+++ b/editors/vscode/tests/interpolation.kd
@@ -1,0 +1,64 @@
+// SYNTAX TEST "source.kaede" "interpolated strings and file recovery"
+
+println($"a {b + c} d")
+//      ^^ punctuation.definition.string.begin.kaede
+//        ^^ string.quoted.double.interpolated.kaede
+//          ^ punctuation.section.embedded.begin.kaede
+//           ^^^^^ meta.interpolation.kaede
+//                ^ punctuation.section.embedded.end.kaede
+//                 ^^ string.quoted.double.interpolated.kaede
+let after_simple = 1
+// <- storage.type.kaede
+
+// a nested string containing a brace must not close the interpolation
+println($"c {\"}\"} d")
+//           ^^ string.quoted.double.kaede
+//             ^ string.quoted.double.kaede
+let after_nested_string = 1
+// <- storage.type.kaede
+
+// balanced braces inside the interpolation
+println($"a{ if true { 1 } else { 2 } }b")
+//           ^^ keyword.control.kaede
+//                         ^^^^ keyword.control.kaede
+//                                     ^^ string.quoted.double.interpolated.kaede
+let after_braces = 1
+// <- storage.type.kaede
+
+// whitespace is allowed between the sigil and the quote
+println($ "hello {name}")
+//      ^^^ punctuation.definition.string.begin.kaede
+//                ^^^^ meta.interpolation.kaede
+let after_space = 1
+// <- storage.type.kaede
+
+// doubled braces are literal, not an interpolation
+println($"{{literal}}")
+//        ^^ constant.character.escape.kaede
+//                 ^^ constant.character.escape.kaede
+let after_literal_braces = 1
+// <- storage.type.kaede
+
+// an unclosed interpolation must not outlive its string
+println($"oops {x")
+//               ^ punctuation.definition.string.end.kaede
+let after_unclosed = 1
+// <- storage.type.kaede
+
+// a brace in a plain string is literal text
+let plain = "{not code}"
+//            ^^^^^^^^ string.quoted.double.kaede
+
+// an interpolation body gets the same rules as top-level code, including the
+// named-argument rule that keeps a primitive-spelled label from reading as a type
+println($"{g(u8=5)} {1.5} {i32}")
+//           ^^ variable.parameter.kaede
+//                   ^^^ constant.numeric.float.kaede
+//                         ^^^ support.type.primitive.kaede
+
+// an odd number of escaped quotes must not let the nested-string rule swallow the
+// closing quote of the interpolated string
+println($"c {\"} d")
+//                ^ punctuation.definition.string.end.kaede
+let after_odd_quote = 1
+// <- storage.type.kaede

--- a/editors/vscode/tests/keywords.kd
+++ b/editors/vscode/tests/keywords.kd
@@ -1,0 +1,38 @@
+// SYNTAX TEST "source.kaede" "keywords, storage and rejected old syntax"
+
+fun add(a: i32, b: i32) -> i32 {
+// <- storage.type.kaede
+//  ^^^ entity.name.function.kaede
+//         ^^^ support.type.primitive.kaede
+//                         ^^^ support.type.primitive.kaede
+  return a + b
+//^^^^^^ keyword.control.kaede
+}
+
+let mut flag = true
+// <- storage.type.kaede
+//  ^^^ storage.modifier.kaede
+//             ^^^^ constant.language.boolean.kaede
+export fun f() {}
+// <- storage.modifier.kaede
+import std.net.http
+// <- keyword.control.import.kaede
+use std.option.Option
+// <- keyword.control.import.kaede
+let n = 1 as i64
+//        ^^ keyword.control.as.kaede
+
+// funny is not a keyword, letter is not let
+let funny = 1
+//  ^^^^^ - storage.type.kaede
+let letter = 1
+//  ^^^^^^ - storage.type.kaede
+
+select {
+// <- keyword.control.concurrency.kaede
+  case v = ch.recv() => {}
+//^^^^ keyword.control.concurrency.kaede
+//                   ^^ keyword.operator.arrow.kaede
+  default => {}
+//^^^^^^^ keyword.control.concurrency.kaede
+}

--- a/editors/vscode/tests/keywords_complete.kd
+++ b/editors/vscode/tests/keywords_complete.kd
@@ -1,0 +1,27 @@
+// SYNTAX TEST "source.kaede" "every keyword in the table"
+
+const MAX: i32 = 1
+// <- storage.modifier.kaede
+extern "C" fun ext() -> i32
+// <- storage.modifier.kaede
+struct S { a: i32 }
+// <- storage.type.kaede
+enum E { A }
+// <- storage.type.kaede
+interface I {}
+// <- storage.type.kaede
+impl<T> Channel<T> {}
+// <- storage.type.kaede
+type T = i32
+// <- storage.type.kaede
+let off = false
+//        ^^^^^ constant.language.boolean.kaede
+spawn worker(ch)
+// <- keyword.control.concurrency.kaede
+loop { break }
+// <- keyword.control.kaede
+//     ^^^^^ keyword.control.kaede
+while cond { f() }
+// <- keyword.control.kaede
+match v { _ => {} }
+// <- keyword.control.kaede

--- a/editors/vscode/tests/literals.kd
+++ b/editors/vscode/tests/literals.kd
@@ -1,0 +1,39 @@
+// SYNTAX TEST "source.kaede" "strings, chars, byte literals and escapes"
+
+let s = "hi\n"
+//      ^ punctuation.definition.string.begin.kaede
+//       ^^ string.quoted.double.kaede
+//         ^^ constant.character.escape.kaede
+let bad = "a\qb"
+//          ^^ invalid.illegal.unknown-escape.kaede
+let c = 'a'
+//      ^^^ string.quoted.single.kaede
+let ce = '\t'
+//        ^^ constant.character.escape.kaede
+let bs = b"raw"
+//       ^^ string.quoted.double.byte.kaede
+let bc = b'x'
+//       ^^ string.quoted.single.byte.kaede
+
+// a trailing b on an identifier does not start a byte string
+let ab = ab"x"
+//       ^^ - string.quoted.double.byte.kaede
+//         ^^^ string.quoted.double.kaede
+
+// an escaped quote stays inside the string
+let q = "a\"b"
+//        ^^ constant.character.escape.kaede
+//          ^ string.quoted.double.kaede
+let after_escapes = 1
+// <- storage.type.kaede
+
+// a char literal holds exactly one character or escape, so an unterminated one
+// ends at the newline instead of scoping the rest of the file as a string
+let half = 'a
+//         ^ punctuation.definition.string.begin.kaede
+let after_half_char = 1
+// <- storage.type.kaede
+let halfb = b'a
+//          ^ string.quoted.single.byte.kaede
+let after_half_byte = 1
+// <- storage.type.kaede

--- a/editors/vscode/tests/multiline.kd
+++ b/editors/vscode/tests/multiline.kd
@@ -1,0 +1,27 @@
+// SYNTAX TEST "source.kaede" "constructs spanning physical lines"
+
+let ml = "line one
+//        ^^^^^^^^ string.quoted.double.kaede
+line two"
+// <- string.quoted.double.kaede
+//      ^ punctuation.definition.string.end.kaede
+let after_ml = 1
+// <- storage.type.kaede
+
+let mi = $"interp
+//         ^^^^^^ string.quoted.double.interpolated.kaede
+{x} tail"
+// <- punctuation.section.embedded.begin.kaede
+//     ^^^^ string.quoted.double.interpolated.kaede
+let after_mi = 1
+// <- storage.type.kaede
+
+/* block
+// <- comment.block.kaede
+   still inside
+// <- comment.block.kaede
+   /* nested across lines
+   */ still inside outer
+//    ^^^^^^^^^^^^^ comment.block.kaede
+*/ let after_block = 1
+// ^^^ storage.type.kaede

--- a/editors/vscode/tests/names.kd
+++ b/editors/vscode/tests/names.kd
@@ -1,0 +1,74 @@
+// SYNTAX TEST "source.kaede" "type, function, constant and variable names"
+
+// a declaration name is taken positionally, with no casing requirement
+struct Point {
+//     ^^^^^ entity.name.type.kaede
+enum Colour { Red }
+//   ^^^^^^ entity.name.type.kaede
+interface Reader {}
+//        ^^^^^^ entity.name.type.kaede
+type Handler = fun(mut Request)
+//   ^^^^^^^ entity.name.type.kaede
+//             ^^^ storage.type.kaede
+//             ^^^ - entity.name.function.kaede
+//                     ^^^^^^^ entity.name.type.kaede
+
+// use sites are taken by capitalisation, so a type imported from another file
+// is coloured even though its declaration is not in view
+let p: Point = build()
+//     ^^^^^ entity.name.type.kaede
+//             ^^^^^ entity.name.function.kaede
+let v = Vector<u8>::new()
+//      ^^^^^^ entity.name.type.kaede
+//             ^^ support.type.primitive.kaede
+
+// a keyword followed directly by a paren is not a call
+if(x) { }
+// <- keyword.control.kaede
+// <- - entity.name.function.kaede
+while(x) { }
+// <- - entity.name.function.kaede
+match(x) { }
+// <- - entity.name.function.kaede
+
+// a call whose name is not ASCII must not be split
+日本語_x1()
+// <- entity.name.function.kaede
+__sys_read(fd)
+// <- entity.name.function.kaede
+
+// two or more leading capitals with no lowercase is a constant, not a type
+const BTREE_PAGE_SIZE: i32 = 4096
+//    ^^^^^^^^^^^^^^^ constant.other.caps.kaede
+//    ^^^^^^^^^^^^^^^ - entity.name.type.kaede
+let n = BTREE_PAGE_SIZE
+//      ^^^^^^^^^^^^^^^ constant.other.caps.kaede
+
+// a trailing lowercase letter makes it a type again
+let e = IoError
+//      ^^^^^^^ entity.name.type.kaede
+let f = ABc
+//      ^^^ entity.name.type.kaede
+
+// plain identifiers, including every segment of a dotted module path --
+// Kaede uses `.` for module paths, so excluding the position after a dot
+// would leave import tails uncoloured
+import std.net.http
+//     ^^^ variable.other.kaede
+//         ^^^ variable.other.kaede
+//             ^^^^ variable.other.kaede
+let dx = other.x
+//  ^^ variable.other.kaede
+//       ^^^^^ variable.other.kaede
+//             ^ variable.other.kaede
+
+// a named-argument label keeps its own scope rather than becoming a variable
+g(u8=5)
+//^^ variable.parameter.kaede
+
+// Kaede does not reserve casing, so a lowercase type name is legal. This is
+// what separates the positional declaration rule from the capitalisation one.
+struct point {
+//     ^^^^^ entity.name.type.kaede
+fun lower(p: point) -> i32 { return 0 }
+//           ^^^^^ - entity.name.type.kaede

--- a/editors/vscode/tests/numbers.kd
+++ b/editors/vscode/tests/numbers.kd
@@ -1,0 +1,38 @@
+// SYNTAX TEST "source.kaede" "integer, float, hex and tuple-index disambiguation"
+
+let f = 0.5
+//      ^^^ constant.numeric.float.kaede
+let h = 0x1F
+//      ^^^^ constant.numeric.integer.kaede
+let h2 = 0X80
+//       ^^^^ constant.numeric.integer.kaede
+
+// hex literals never take a fractional part: 0x80.5 is three tokens, 0x80 . 5
+let hf = 0x80.5
+//       ^^^^ constant.numeric.integer.kaede
+//           ^ keyword.operator.kaede
+//            ^ constant.numeric.integer.kaede
+
+// tuple index chains are two integers, not a float
+let a = tup.0.1
+//          ^ constant.numeric.integer.kaede
+//            ^ constant.numeric.integer.kaede
+let b = tup. 0.1
+//           ^ constant.numeric.integer.kaede
+//             ^ constant.numeric.integer.kaede
+let c = self.0
+//      ^^^^ variable.language.self.kaede
+//           ^ constant.numeric.integer.kaede
+
+// a method call on an integer literal is not a float
+let d = 1.foo()
+//      ^ constant.numeric.integer.kaede
+
+// 0x with no hex digit is integer 0 followed by an identifier
+let e = 0x
+//      ^ constant.numeric.integer.kaede
+//       ^ - constant.numeric.integer.kaede
+
+// digits inside an identifier are not numbers
+let ab123 = 1
+//  ^^^^^ - constant.numeric.integer.kaede

--- a/editors/vscode/tests/operators.kd
+++ b/editors/vscode/tests/operators.kd
@@ -1,0 +1,53 @@
+// SYNTAX TEST "source.kaede" "operator alternation branches"
+
+let a = x + y - z * w / v % u
+//        ^ keyword.operator.kaede
+//            ^ keyword.operator.kaede
+//                ^ keyword.operator.kaede
+//                    ^ keyword.operator.kaede
+//                        ^ keyword.operator.kaede
+
+let b = !p & q | r ^ ~s
+//      ^ keyword.operator.kaede
+//         ^ keyword.operator.kaede
+//             ^ keyword.operator.kaede
+//                 ^ keyword.operator.kaede
+//                   ^ keyword.operator.kaede
+
+fun probe(header: [u8]) -> Option<[u8]> {
+  upgrade := header_value(header, b"Upgrade")?
+//                                           ^ keyword.operator.kaede
+  return Option::Some(upgrade)
+}
+
+// Each multi-character operator carries its own sub-scope, so these assertions
+// fail if the shorter branch ever wins.
+n += 1
+//^^ keyword.operator.assignment.kaede
+n -= 1
+//^^ keyword.operator.assignment.kaede
+n *= 2
+//^^ keyword.operator.assignment.kaede
+n /= 2
+//^^ keyword.operator.assignment.kaede
+n %= 2
+//^^ keyword.operator.assignment.kaede
+
+let e = a == b != c <= d >= e && f || g
+//        ^^ keyword.operator.comparison.kaede
+//             ^^ keyword.operator.comparison.kaede
+//                  ^^ keyword.operator.comparison.kaede
+//                       ^^ keyword.operator.comparison.kaede
+//                            ^^ keyword.operator.logical.kaede
+//                                 ^^ keyword.operator.logical.kaede
+
+let f = a << 8 | b >> 2
+//        ^^ keyword.operator.bitwise.kaede
+//                 ^^ keyword.operator.bitwise.kaede
+
+mut app := App::new()
+//      ^^ keyword.operator.assignment.kaede
+//            ^^ keyword.operator.namespace.kaede
+
+ch <- v
+// ^^ keyword.operator.arrow.kaede

--- a/editors/vscode/tests/real_code.kd
+++ b/editors/vscode/tests/real_code.kd
@@ -1,0 +1,69 @@
+// SYNTAX TEST "source.kaede" "constructs taken from library/src and example"
+
+export extern "C" fun kaede_io_write(fd: i32, buf: *u8, ...) -> i32
+// <- storage.modifier.kaede
+//     ^^^^^^ storage.modifier.kaede
+//            ^^^ string.quoted.double.kaede
+//                ^^^ storage.type.kaede
+//                    ^^^^^^^^^^^^^^ entity.name.function.kaede
+//                                       ^^^ support.type.primitive.kaede
+//                                                 ^ keyword.operator.kaede
+//                                                  ^^ support.type.primitive.kaede
+//                                                      ^^^ keyword.operator.variadic.kaede
+//                                                           ^^ keyword.operator.arrow.kaede
+//                                                              ^^^ support.type.primitive.kaede
+
+export type Handler = fun(mut Request, mut Response)
+//     ^^^^ storage.type.kaede
+//          ^^^^^^^ - entity.name.function.kaede
+//                    ^^^ storage.type.kaede
+//                    ^^^ - entity.name.function.kaede
+//                        ^^^ storage.modifier.kaede
+
+let mut buf = [0 as u8; 256]
+//            ^ punctuation.brackets.square.kaede
+//             ^ constant.numeric.integer.kaede
+//               ^^ keyword.control.as.kaede
+//                  ^^ support.type.primitive.kaede
+//                    ^ punctuation.terminator.kaede
+//                      ^^^ constant.numeric.integer.kaede
+//                         ^ punctuation.brackets.square.kaede
+
+let line = header[0:i]
+//               ^ punctuation.brackets.square.kaede
+//                 ^ keyword.operator.kaede
+//                   ^ punctuation.brackets.square.kaede
+
+app.get("/x", |req, res| { res.send("k") })
+//     ^ punctuation.brackets.round.kaede
+//          ^ punctuation.separator.kaede
+//            ^ keyword.operator.kaede
+//                     ^ keyword.operator.kaede
+//                       ^ punctuation.brackets.curly.kaede
+//                                       ^ punctuation.brackets.curly.kaede
+
+export fun assert(cond: bool, msg: str = "assertion failed") {}
+//                      ^^^^ support.type.primitive.kaede
+//                            ^^^ - variable.parameter.kaede
+//                                 ^^^ support.type.primitive.kaede
+//                                       ^^^^^^^^^^^^^^^^^^ string.quoted.double.kaede
+
+import rust::comment_app
+// <- keyword.control.import.kaede
+//         ^^ keyword.operator.namespace.kaede
+
+let s = String { bytes: Vector<u8>::from_slice(b) }
+//             ^ punctuation.brackets.curly.kaede
+//                             ^^ support.type.primitive.kaede
+//                                ^^ keyword.operator.namespace.kaede
+
+fun to_string(mut self) -> String { return self.0 }
+//            ^^^ storage.modifier.kaede
+//                ^^^^ variable.language.self.kaede
+//                                         ^^^^ variable.language.self.kaede
+//                                              ^ constant.numeric.integer.kaede
+
+let (found, idx) = search(k)
+//  ^ punctuation.brackets.round.kaede
+//        ^ punctuation.separator.kaede
+//             ^ punctuation.brackets.round.kaede

--- a/editors/vscode/tests/types.kd
+++ b/editors/vscode/tests/types.kd
@@ -1,0 +1,28 @@
+// SYNTAX TEST "source.kaede" "fundamental types and named arguments"
+
+let x: str = "a"
+//     ^^^ support.type.primitive.kaede
+let p: *u8 = q
+//      ^^ support.type.primitive.kaede
+let s: [u8] = t
+//      ^^ support.type.primitive.kaede
+let v: Vector<i64> = w
+//            ^^^ support.type.primitive.kaede
+
+// a named argument label is not a type, even when it is spelled like one
+g(u8=5)
+//^^ variable.parameter.kaede
+//  ^ keyword.operator.kaede
+h(a, bool=1)
+//   ^^^^ variable.parameter.kaede
+
+// a field access spelled like a type is not a type
+let y = s.bool
+//        ^^^^ - support.type.primitive.kaede
+
+// operators
+mut app := App::new()
+//      ^^ keyword.operator.assignment.kaede
+//            ^^ keyword.operator.namespace.kaede
+ch <- v
+// ^^ keyword.operator.arrow.kaede

--- a/editors/vscode/tests/types_all.kd
+++ b/editors/vscode/tests/types_all.kd
@@ -1,0 +1,30 @@
+// SYNTAX TEST "source.kaede" "all thirteen fundamental types and the dotted-path guard"
+
+fun all(a: i8, b: u8, c: i16, d: u16, e: i32, f: u32, g: i64, h: u64) {}
+//         ^^ support.type.primitive.kaede
+//                ^^ support.type.primitive.kaede
+//                       ^^^ support.type.primitive.kaede
+//                               ^^^ support.type.primitive.kaede
+//                                       ^^^ support.type.primitive.kaede
+//                                               ^^^ support.type.primitive.kaede
+//                                                       ^^^ support.type.primitive.kaede
+//                                                               ^^^ support.type.primitive.kaede
+
+fun all2(a: f32, b: f64, c: char, d: bool, e: str) {}
+//          ^^^ support.type.primitive.kaede
+//                  ^^^ support.type.primitive.kaede
+//                          ^^^^ support.type.primitive.kaede
+//                                   ^^^^ support.type.primitive.kaede
+//                                            ^^^ support.type.primitive.kaede
+
+// a leading path segment named like a primitive is not a primitive
+import char.utils
+//     ^^^^ - support.type.primitive.kaede
+use str.helpers
+//  ^^^ - support.type.primitive.kaede
+
+// punctuation inside an interpolation body
+println($"{f(a, b)}")
+//          ^ punctuation.brackets.round.kaede
+//            ^ punctuation.separator.kaede
+//               ^ punctuation.brackets.round.kaede

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
             cmake
             pkg-config
             python3
+            nodejs
           ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
             valgrind
           ];


### PR DESCRIPTION
Closes #400.

Replaces `editors/vscode/syntaxes/kaede.tmLanguage.json` — previously the one-line alias `{"patterns": [{"include": "source.rust"}]}` — with a grammar written for Kaede, and stands up the harness and CI that keep it correct.

Three commits: the language-client fix, the grammar, and the workflow rename. Each is green on its own.

## Four rules needed more than the obvious pattern

Each was checked against the compiler and against real vscode-textmate output rather than assumed.

**Interpolated strings.** `parse_interpolated_parts` tracks `in_string` and counts brace depth, so all three of these compile:

```kaede
println($"c {\"}\"} d")                        // prints:  c } d
println($"a{ if true { 1 } else { 2 } }b")     // prints:  a1b
println($ "hello {name}")                      // prints:  hello world
```

A naive `begin: "{"` / `end: "}"` rule ends at the inner `}` on the second, and on the first opens a string whose escape rule eats the closing quote — scoping **every subsequent line of the file** as string. `include: $self` does not rescue it, because a conservative grammar has no block rule to recurse through. The implemented rule uses a nested-string sub-rule keyed on the escaped form `\"`, an explicit balanced-brace sub-rule, `begin: "\\$[ \\t]*\""` for the third case, and `(?=")` in the end pattern of all three so an unclosed interpolation cannot outlive its string.

**Block comments.** `eat_block_comment` is a bare character scan with a depth counter — it knows nothing about strings or `//`, so `/* x // */ code` and `/* he said "no */ code` both terminate at the first `*/`. The block rule therefore includes **only itself**; giving it string or line-comment children turns the rest of the file into a comment.

**`char` and `byte-char` end at `'|$`; strings do not.** `char_literal` consumes exactly one character or escape, so a char literal can never span a line and the newline guard is correct — without it `let c = 'a`, the state the editor is in between the two apostrophe keystrokes, turns the rest of the file into a string. `string_literal` loops past newlines, so strings legitimately span lines and the same guard would break them.

**Numbers.** `prev_was_dot` lives on the lexer cursor and whitespace emits no token, so `tup. 0.1` is a tuple-index chain exactly like `tup.0.1`. Oniguruma's variable-length lookbehind `(?<!\.\s*)` covers both. The hex branch returns before the fractional part, so `0x80.5` is `0x80` then `.5` as two tokens.

## Name colouring, and why it does not mirror the Rust grammar

Type names, call sites and plain identifiers follow what VS Code's bundled Rust grammar does — a positional rule on `struct`/`enum`/`interface`/`type` with no casing requirement, a call-site rule, and a capitalisation heuristic for use sites, which is the only lexical way to colour a type imported from another file. `constant.other.caps` runs ahead of the heuristic because Kaede's constants are SCREAMING_CASE; `BTREE_PAGE_SIZE` appears 43 times in `library/src` and would otherwise read as a type.

Rust's *forms* do not transfer. Its call rule is a begin/end that consumes the closing paren, which mis-scopes `f() < g()`; it sits before its keywords, which makes `if(x)` scope `if` as a function name; its identifier classes are ASCII, so `fun 日本語_x1()` scopes only `_x1`, splitting the name; and its `variable.other` excludes the position after a `.` to keep field accesses uncoloured, which in Kaede — where `.` is also the module path separator — would leave every `import a.b.c` tail uncoloured instead.

Mirroring it wholesale was checked and rejected. Its `use` rule is `begin: "use\s"` / `end: ";"`, and Kaede has no statement terminator: the only 34 semicolons in the corpus are inside `[0; 4096]` array literals, so 19 of 37 stdlib files would have everything after their first `use` swallowed into one unscoped run. Its interpolation rule is a single-line format-placeholder match that picks the *wrong* braces on nested code. Its literal rules certify `1_000`, `1e10`, `42u8`, `0b1010`, `0o17` and `1.5f64` as valid when the lexer rejects every one, and its escape rule ends in a `.` alternative that accepts `\q`, which panics the lexer.

## Scope names, chosen against real theme JSON

- `keyword.declaration` is not a TextMate naming convention, has no rule in any default theme, and falls back to bare `keyword` — rendering *identically to* `keyword.control` in Monokai and One Dark Pro. Declarations use `storage.type` / `storage.modifier`.
- `keyword.operator.cast` resolves to plain body text in One Dark Pro, i.e. `as` would vanish. Uses `keyword.control.as`.
- `meta.embedded.*` marks a *different* language and pairs with an `embeddedLanguages` map; every theme also maps it to the body foreground, silently resetting the span. Interpolation uses `meta.interpolation` with `punctuation.section.embedded.*` braces, which all six themes colour.
- The 13 fundamental types keep `support.type.primitive` rather than Rust's `entity.name.type.numeric`: `entity.name.*` is the namespace for names being declared, and the rename collides with Monokai's function colour.
- Rust's nine-way `keyword.operator` split is not adopted for colour — no theme distinguishes the children — but the split is kept, because assertions check the scope at a column rather than token boundaries, so a shared name lets `<<` tokenized as two `<` satisfy the test.

## One accepted tradeoff

The 13 fundamental type names are ordinary identifiers, not keywords (`compiler/lex/src/tests.rs` asserts `i32` lexes as `Ident`). Highlighting them means a parameter named `u8` is painted as a type:

```kaede
fun g(u8: i32) -> i32 { return 1 }   // both u8 and i32 render as a primitive type
```

Mitigated by scoping named-argument labels first, so `g(u8=5)` keeps its label, and by excluding `.`-adjacent positions so dotted module paths survive. Which way #402 is fixed decides whether the caveat can be dropped entirely.

## Testing

A fixture alone carries no expected output, so nothing in a diff would reveal a re-scoped token. `vscode-tmgrammar-test` puts the expected scopes in the fixture:

```
let mut flag = true
// <- storage.type.kaede
//  ^^^ storage.modifier.kaede
//             ^^^^ constant.language.boolean.kaede
```

16 fixtures, 285 assertions. Every rule described above is mutation-tested — removing it turns a test red, verified individually. Mutation-testing the grammar as a whole initially left 38 of 63 rules and branches unpinned, which is where the multi-line, guard, escape, keyword, primitive and real-code fixtures come from.

Tokenizing every `.kd` file under `library/src` and `example/`: 37 files, 94975 code characters, zero `invalid.*` false positives, no file leaking its scope stack past EOF. 80.4% of code characters carry a visibly distinct scope, up from roughly a fifth.

## CI

No workflow touched `editors/` before, so neither the grammar nor the extension's own `tsc` was ever checked — and the compile was in fact broken. The new workflow runs both, plus a step requiring every fixture to carry at least one assertion, since an assertion-free fixture otherwise passes silently. It is scoped by `paths` to `editors/vscode` and to itself, because nothing it runs reads a line of Rust; that also means it must not be a required check, as a workflow skipped by a path filter never reports and a required check that never reports blocks a merge forever.

Both Nix workflows named their job `Check and test (Nix)`, so they reported under the same context and a required-checks rule could not tell them apart. Renamed, and both gain `pull_request` so a fork PR gets CI at all, with `push` scoped to `main` so a same-repo PR does not run everything twice.

`flake.nix` gains `nodejs`, since CLAUDE.md points contributors at `nix develop` and none of the newly gated commands existed there.

## Out of scope

Semantic tokens (#7). The website and Linguist follow-ups described in #400. The pre-existing error handling in `extension.ts`, filed as #405.
