### PR TITLE
feat(lang): infer const declaration types

### DIFF
--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -367,15 +367,15 @@ fn let_statement() -> anyhow::Result<()> {
 
 #[test]
 fn top_level_const_statement() -> anyhow::Result<()> {
-    let program = r"const BNODE_LEAF: u16 = 2
+    let program = r"const BNODE_LEAF = 2
 
     fun main() -> i32 {
-        let kind: u16 = BNODE_LEAF
-        return kind as i32
+        return BNODE_LEAF
     }";
 
     assert_eq!(exec(program)?, 2);
 
+    // Explicit annotations remain supported when the exported type is intentional.
     let program = r"const BASE: u32 = 2
     const LEN: u32 = BASE + 2
 

--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -367,15 +367,15 @@ fn let_statement() -> anyhow::Result<()> {
 
 #[test]
 fn top_level_const_statement() -> anyhow::Result<()> {
-    let program = r"const BNODE_LEAF = 2
+    let program = r"const BNODE_LEAF: u16 = 2
 
     fun main() -> i32 {
-        return BNODE_LEAF
+        let kind: u16 = BNODE_LEAF
+        return kind as i32
     }";
 
     assert_eq!(exec(program)?, 2);
 
-    // Explicit annotations remain supported when the exported type is intentional.
     let program = r"const BASE: u32 = 2
     const LEN: u32 = BASE + 2
 
@@ -390,7 +390,42 @@ fn top_level_const_statement() -> anyhow::Result<()> {
 }
 
 #[test]
+fn inferred_top_level_const_statement() -> anyhow::Result<()> {
+    let program = r"const BASE = 48
+    const RESULT = BASE + 10
+
+    fun main() -> i32 {
+        return RESULT
+    }";
+
+    assert_eq!(exec(program)?, 58);
+
+    Ok(())
+}
+
+#[test]
 fn local_const_statement() -> anyhow::Result<()> {
+    let program = r"fun main() -> i32 {
+        const base: i32 = 48
+        const result: i32 = base + 10
+        return result
+    }";
+
+    assert_eq!(exec(program)?, 58);
+
+    let program = r"fun main() -> i32 {
+        const len: u32 = 4
+        let xs = [58; len]
+        return xs[3]
+    }";
+
+    assert_eq!(exec(program)?, 58);
+
+    Ok(())
+}
+
+#[test]
+fn inferred_local_const_statement() -> anyhow::Result<()> {
     let program = r"fun main() -> i32 {
         const base = 48
         const result = base + 10
@@ -399,9 +434,8 @@ fn local_const_statement() -> anyhow::Result<()> {
 
     assert_eq!(exec(program)?, 58);
 
-    // An explicit annotation remains supported.
     let program = r"fun main() -> i32 {
-        const len: u32 = 4
+        const len = 4
         let xs = [58; len]
         return xs[3]
     }";

--- a/compiler/codegen/src/tests.rs
+++ b/compiler/codegen/src/tests.rs
@@ -392,13 +392,14 @@ fn top_level_const_statement() -> anyhow::Result<()> {
 #[test]
 fn local_const_statement() -> anyhow::Result<()> {
     let program = r"fun main() -> i32 {
-        const base: i32 = 48
-        const result: i32 = base + 10
+        const base = 48
+        const result = base + 10
         return result
     }";
 
     assert_eq!(exec(program)?, 58);
 
+    // An explicit annotation remains supported.
     let program = r"fun main() -> i32 {
         const len: u32 = 4
         let xs = [58; len]

--- a/compiler/parse/src/stmt.rs
+++ b/compiler/parse/src/stmt.rs
@@ -220,8 +220,11 @@ impl Parser {
         let start = self.consume(&TokenKind::Const).unwrap().start;
         let name = self.ident()?;
 
-        self.consume(&TokenKind::Colon)?;
-        let ty = self.ty()?;
+        let ty = if self.consume_b(&TokenKind::Colon) {
+            Some(self.ty()?)
+        } else {
+            None
+        };
 
         self.consume(&TokenKind::Eq)?;
         let init = self.expr()?;
@@ -230,7 +233,7 @@ impl Parser {
         Ok(Const {
             name,
             init: init.into(),
-            ty: ty.into(),
+            ty: ty.unwrap_or_else(|| Ty::new_var(span)).into(),
             span,
         })
     }

--- a/compiler/parse/src/top.rs
+++ b/compiler/parse/src/top.rs
@@ -142,8 +142,11 @@ impl Parser {
         let start = self.consume(&TokenKind::Const).unwrap().start;
         let name = self.ident()?;
 
-        self.consume(&TokenKind::Colon)?;
-        let ty = self.ty()?;
+        let ty = if self.consume_b(&TokenKind::Colon) {
+            Some(self.ty()?)
+        } else {
+            None
+        };
 
         self.consume(&TokenKind::Eq)?;
         let init = self.expr()?;
@@ -153,7 +156,7 @@ impl Parser {
             vis,
             name,
             init: init.into(),
-            ty: ty.into(),
+            ty: ty.unwrap_or_else(|| Ty::new_var(span)).into(),
             span,
         })
     }

--- a/compiler/semantic/src/stmt.rs
+++ b/compiler/semantic/src/stmt.rs
@@ -135,9 +135,25 @@ impl SemanticAnalyzer {
             .into());
         }
 
-        let annotated = self.analyze_type(&node.ty)?;
-        let init = self.analyze_expr_with_expected_type(&node.init, annotated.clone())?;
-        let const_ty = ir::ty::change_mutability_dup(annotated, ir::ty::Mutability::Not);
+        let (init, const_ty) = if node.ty.kind.is_inferred() {
+            let init = self.analyze_expr(&node.init)?;
+            let inferred = if matches!(init.ty.kind.as_ref(), ir::ty::TyKind::Var(_)) {
+                self.infer_context.fresh()
+            } else {
+                init.ty.clone()
+            };
+            (
+                init,
+                ir::ty::change_mutability_dup(inferred, ir::ty::Mutability::Not),
+            )
+        } else {
+            let annotated = self.analyze_type(&node.ty)?;
+            let init = self.analyze_expr_with_expected_type(&node.init, annotated.clone())?;
+            (
+                init,
+                ir::ty::change_mutability_dup(annotated, ir::ty::Mutability::Not),
+            )
+        };
         let const_value = self
             .evaluate_integer_const_expr(&node.init)
             .map(ConstValue::Integer);

--- a/compiler/semantic/src/top.rs
+++ b/compiler/semantic/src/top.rs
@@ -8,7 +8,7 @@ use crate::{context::AnalyzeCommand, rust_import, SemanticAnalyzer, SemanticErro
 use kaede_symbol_table::{
     ConstValue, GenericBuiltinSliceInfo, GenericEnumInfo, GenericFuncInfo, GenericImplInfo,
     GenericInfo, GenericKind, GenericStructInfo, ResolvedGenericParam, ResolvedGenericParams,
-    SymbolTable, SymbolTableValue, SymbolTableValueKind, VariableInfo,
+    SymbolResolver, SymbolTable, SymbolTableValue, SymbolTableValueKind, VariableInfo,
 };
 
 use kaede_ast::{self as ast};
@@ -28,6 +28,32 @@ pub enum TopLevelAnalysisResult {
 }
 
 impl SemanticAnalyzer {
+    fn infer_top_const_initializer(
+        &mut self,
+        init: &mut ir::expr::Expr,
+    ) -> anyhow::Result<Rc<ir::ty::Ty>> {
+        use kaede_type_infer::TypeInferrer;
+
+        let module = &self.modules[self.current_module_path()];
+        let resolver = SymbolResolver::merge_for_inference(
+            module.get_symbol_tables(),
+            self.build_qualified_symbol_table(),
+        );
+        let mut inferrer = TypeInferrer::new(
+            resolver,
+            Rc::new(ir::ty::Ty::new_unit()),
+            self.infer_context.type_var_allocator.clone(),
+        );
+
+        inferrer.infer_expr(init)?;
+        inferrer.apply_expr(init)?;
+        self.merge_generated_callable_substitutions(
+            inferrer.into_generated_callable_substitutions(),
+        );
+
+        Ok(init.ty.clone())
+    }
+
     fn fn_decl_requires_delayed_inference(decl: &ir::top::FnDecl) -> bool {
         Self::fn_decl_has_unresolved_types(decl)
     }
@@ -1106,9 +1132,15 @@ impl SemanticAnalyzer {
             .into());
         }
 
-        let annotated = self.analyze_type(&node.ty)?;
-        let _init = self.analyze_expr_with_expected_type(&node.init, annotated.clone())?;
-        let const_ty = ir::ty::change_mutability_dup(annotated, ir::ty::Mutability::Not);
+        let const_ty = if node.ty.kind.is_inferred() {
+            let mut init = self.analyze_expr(&node.init)?;
+            let inferred = self.infer_top_const_initializer(&mut init)?;
+            ir::ty::change_mutability_dup(inferred, ir::ty::Mutability::Not)
+        } else {
+            let annotated = self.analyze_type(&node.ty)?;
+            let _init = self.analyze_expr_with_expected_type(&node.init, annotated.clone())?;
+            ir::ty::change_mutability_dup(annotated, ir::ty::Mutability::Not)
+        };
         let const_value = self
             .evaluate_integer_const_expr(&node.init)
             .map(ConstValue::Integer);

--- a/compiler/semantic/tests/import.rs
+++ b/compiler/semantic/tests/import.rs
@@ -821,6 +821,24 @@ fn import_exported_top_level_const() -> anyhow::Result<()> {
 fn import_top_level_const_via_use() -> anyhow::Result<()> {
     ImportTestCase {
         name: "top_level_const_via_use",
+        modules: HashMap::from([("constants", "export const ANSWER: i32 = 42")]),
+        main_content: r#"
+            import constants
+            use constants.ANSWER
+            fun main() -> i32 {
+                return ANSWER
+            }
+        "#,
+        expected_min_top_levels: 2,
+        should_fail: false,
+    }
+    .run()
+}
+
+#[test]
+fn import_inferred_top_level_const_via_use() -> anyhow::Result<()> {
+    ImportTestCase {
+        name: "inferred_top_level_const_via_use",
         modules: HashMap::from([("constants", "export const ANSWER = 42")]),
         main_content: r#"
             import constants

--- a/compiler/semantic/tests/import.rs
+++ b/compiler/semantic/tests/import.rs
@@ -821,7 +821,7 @@ fn import_exported_top_level_const() -> anyhow::Result<()> {
 fn import_top_level_const_via_use() -> anyhow::Result<()> {
     ImportTestCase {
         name: "top_level_const_via_use",
-        modules: HashMap::from([("constants", "export const ANSWER: i32 = 42")]),
+        modules: HashMap::from([("constants", "export const ANSWER = 42")]),
         main_content: r#"
             import constants
             use constants.ANSWER

--- a/compiler/semantic/tests/stmt.rs
+++ b/compiler/semantic/tests/stmt.rs
@@ -64,7 +64,7 @@ fn let_and_access() -> anyhow::Result<()> {
 fn local_const() -> anyhow::Result<()> {
     semantic_analyze(
         "fun f() -> i32 {
-            const base = 48
+            const base: i32 = 48
             const result: i32 = base + 10
             return result
         }
@@ -74,7 +74,33 @@ fn local_const() -> anyhow::Result<()> {
 }
 
 #[test]
+fn inferred_local_const() -> anyhow::Result<()> {
+    semantic_analyze(
+        "fun f() -> i32 {
+            const base = 48
+            const result = base + 10
+            return result
+        }
+    ",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn local_const_array_repeat_count() -> anyhow::Result<()> {
+    semantic_analyze(
+        "fun f() {
+            const base: u32 = 2
+            const len: u32 = base + 2
+            let _ = [0; len]
+        }
+    ",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn inferred_local_const_array_repeat_count() -> anyhow::Result<()> {
     semantic_analyze(
         "fun f() {
             const base = 2
@@ -88,6 +114,21 @@ fn local_const_array_repeat_count() -> anyhow::Result<()> {
 
 #[test]
 fn local_const_rejects_runtime_initializer() -> anyhow::Result<()> {
+    semantic_analyze_expect_error(
+        "fun value() -> i32 {
+            return 1
+        }
+
+        fun f() {
+            const x: i32 = value()
+        }
+    ",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn inferred_local_const_rejects_runtime_initializer() -> anyhow::Result<()> {
     semantic_analyze_expect_error(
         "fun value() -> i32 {
             return 1
@@ -116,6 +157,20 @@ fn local_const_rejects_assignment() -> anyhow::Result<()> {
 #[test]
 fn top_level_const() -> anyhow::Result<()> {
     semantic_analyze(
+        "const BNODE_LEAF: u16 = 2
+
+        fun main() -> i32 {
+            let kind: u16 = BNODE_LEAF
+            return kind as i32
+        }
+    ",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn inferred_top_level_const() -> anyhow::Result<()> {
+    semantic_analyze(
         "export const BNODE_LEAF = 2
 
         fun main() -> i32 {
@@ -128,6 +183,20 @@ fn top_level_const() -> anyhow::Result<()> {
 
 #[test]
 fn top_level_const_arithmetic() -> anyhow::Result<()> {
+    semantic_analyze(
+        "const BASE: u32 = 2
+        const LEN: u32 = BASE + 2
+
+        fun f() {
+            let _ = [0; LEN]
+        }
+    ",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn inferred_top_level_const_arithmetic() -> anyhow::Result<()> {
     semantic_analyze(
         "const BASE = 2
         const LEN = BASE + 2
@@ -147,6 +216,19 @@ fn top_level_const_rejects_runtime_initializer() -> anyhow::Result<()> {
             return 1
         }
 
+        const X: i32 = value()
+    ",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn inferred_top_level_const_rejects_runtime_initializer() -> anyhow::Result<()> {
+    semantic_analyze_expect_error(
+        "fun value() -> i32 {
+            return 1
+        }
+
         const X = value()
     ",
     )?;
@@ -156,7 +238,7 @@ fn top_level_const_rejects_runtime_initializer() -> anyhow::Result<()> {
 #[test]
 fn top_level_const_rejects_assignment() -> anyhow::Result<()> {
     semantic_analyze_expect_error(
-        "const X = 1
+        "const X: i32 = 1
 
         fun f() {
             X = 2

--- a/compiler/semantic/tests/stmt.rs
+++ b/compiler/semantic/tests/stmt.rs
@@ -116,11 +116,10 @@ fn local_const_rejects_assignment() -> anyhow::Result<()> {
 #[test]
 fn top_level_const() -> anyhow::Result<()> {
     semantic_analyze(
-        "const BNODE_LEAF: u16 = 2
+        "export const BNODE_LEAF = 2
 
         fun main() -> i32 {
-            let kind: u16 = BNODE_LEAF
-            return kind as i32
+            return BNODE_LEAF
         }
     ",
     )?;
@@ -130,8 +129,8 @@ fn top_level_const() -> anyhow::Result<()> {
 #[test]
 fn top_level_const_arithmetic() -> anyhow::Result<()> {
     semantic_analyze(
-        "const BASE: u32 = 2
-        const LEN: u32 = BASE + 2
+        "const BASE = 2
+        const LEN = BASE + 2
 
         fun f() {
             let _ = [0; LEN]
@@ -148,7 +147,7 @@ fn top_level_const_rejects_runtime_initializer() -> anyhow::Result<()> {
             return 1
         }
 
-        const X: i32 = value()
+        const X = value()
     ",
     )?;
     Ok(())
@@ -157,7 +156,7 @@ fn top_level_const_rejects_runtime_initializer() -> anyhow::Result<()> {
 #[test]
 fn top_level_const_rejects_assignment() -> anyhow::Result<()> {
     semantic_analyze_expect_error(
-        "const X: i32 = 1
+        "const X = 1
 
         fun f() {
             X = 2

--- a/compiler/semantic/tests/stmt.rs
+++ b/compiler/semantic/tests/stmt.rs
@@ -64,7 +64,7 @@ fn let_and_access() -> anyhow::Result<()> {
 fn local_const() -> anyhow::Result<()> {
     semantic_analyze(
         "fun f() -> i32 {
-            const base: i32 = 48
+            const base = 48
             const result: i32 = base + 10
             return result
         }
@@ -77,8 +77,8 @@ fn local_const() -> anyhow::Result<()> {
 fn local_const_array_repeat_count() -> anyhow::Result<()> {
     semantic_analyze(
         "fun f() {
-            const base: u32 = 2
-            const len: u32 = base + 2
+            const base = 2
+            const len = base + 2
             let _ = [0; len]
         }
     ",
@@ -94,7 +94,7 @@ fn local_const_rejects_runtime_initializer() -> anyhow::Result<()> {
         }
 
         fun f() {
-            const x: i32 = value()
+            const x = value()
         }
     ",
     )?;

--- a/website/docs/language/overview.md
+++ b/website/docs/language/overview.md
@@ -54,7 +54,6 @@ vec := Vector<i32>::new()
 mut app := std.net.http.App::new()
 let count: i32 = 3
 const page_size = 4096
-const header_size: u64 = 64
 ```
 
 In practice, current Kaede code tends to use:
@@ -62,9 +61,9 @@ In practice, current Kaede code tends to use:
 - `:=` for local bindings when the type is obvious from the right-hand side
 - `mut ... :=` for mutable locals with inferred types
 - `let` when you want the explicit `let` form, especially with a type annotation such as `let count: i32 = 3`
-- `const` for local compile-time constants, with an optional type annotation
+- `const` for compile-time constants
 
-`let x = 1` and `let mut x = 1` are also valid. A `const` infers its type when the annotation is omitted and always requires a compile-time constant initializer. An explicit annotation remains useful when the constant is part of a public API and its type should not change with its initializer.
+`let x = 1` and `let mut x = 1` are also valid. A `const` initializer must be a compile-time constant.
 
 ## Functions and return types
 

--- a/website/docs/language/overview.md
+++ b/website/docs/language/overview.md
@@ -64,7 +64,7 @@ In practice, current Kaede code tends to use:
 - `let` when you want the explicit `let` form, especially with a type annotation such as `let count: i32 = 3`
 - `const` for local compile-time constants, with an optional type annotation
 
-`let x = 1` and `let mut x = 1` are also valid. A local `const` infers its type when the annotation is omitted and always requires a compile-time constant initializer. Top-level constants still require an explicit type annotation.
+`let x = 1` and `let mut x = 1` are also valid. A `const` infers its type when the annotation is omitted and always requires a compile-time constant initializer. An explicit annotation remains useful when the constant is part of a public API and its type should not change with its initializer.
 
 ## Functions and return types
 

--- a/website/docs/language/overview.md
+++ b/website/docs/language/overview.md
@@ -53,7 +53,8 @@ Kaede supports both the short declaration form and `let` bindings:
 vec := Vector<i32>::new()
 mut app := std.net.http.App::new()
 let count: i32 = 3
-const page_size: u64 = 4096
+const page_size = 4096
+const header_size: u64 = 64
 ```
 
 In practice, current Kaede code tends to use:
@@ -61,9 +62,9 @@ In practice, current Kaede code tends to use:
 - `:=` for local bindings when the type is obvious from the right-hand side
 - `mut ... :=` for mutable locals with inferred types
 - `let` when you want the explicit `let` form, especially with a type annotation such as `let count: i32 = 3`
-- `const` for typed local compile-time constants
+- `const` for local compile-time constants, with an optional type annotation
 
-`let x = 1` and `let mut x = 1` are also valid. `const` currently requires a type annotation and a compile-time constant initializer.
+`let x = 1` and `let mut x = 1` are also valid. A local `const` infers its type when the annotation is omitted and always requires a compile-time constant initializer. Top-level constants still require an explicit type annotation.
 
 ## Functions and return types
 


### PR DESCRIPTION
## Summary

- allow local and top-level const declarations to omit their type annotation
- infer local consts through the surrounding function inference context
- infer top-level consts from their initializer before registering the module item
- preserve explicit annotations and compile-time initializer checks
- cover exported/imported inferred constants and update the language overview

Top-level constants retain a single item type. An unconstrained integer initializer therefore defaults to i32; constants whose API requires u16 or u64 should keep an explicit annotation.

The constants under example/ were reviewed. All occur in example/database and intentionally remain annotated because they are exported u16/u64 API constants or an internal u64 size constant; omitting those annotations would infer i32.

## Verification

- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- cargo test -p kaede_semantic local_const --release
- cargo test -p kaede_semantic top_level_const --release
- cargo test -p kaede_codegen local_const_statement --release
- cargo test -p kaede_codegen top_level_const_statement --release
- cargo test --release --no-fail-fast (compiler, semantic, codegen, and most driver tests passed; the same six environment/flaky targets remain: fs and two HTTP cases, nightly rustdoc-dependent Rust import/run cases, and valgrind permission failures)

Closes #324