### PR TITLE
refactor(lex): stop reserving fn and pub

### DIFF
--- a/compiler/lex/src/lib.rs
+++ b/compiler/lex/src/lib.rs
@@ -164,7 +164,6 @@ impl Cursor<'_> {
                 match ident.as_str() {
                     // Reserved words
                     "fun" => self.create_token(TokenKind::Fun),
-                    "fn" => self.create_token(TokenKind::OldFn),
                     "return" => self.create_token(TokenKind::Return),
                     "let" => self.create_token(TokenKind::Let),
                     "const" => self.create_token(TokenKind::Const),
@@ -180,7 +179,6 @@ impl Cursor<'_> {
                     "false" => self.create_token(TokenKind::False),
                     "import" => self.create_token(TokenKind::Import),
                     "export" => self.create_token(TokenKind::Export),
-                    "pub" => self.create_token(TokenKind::OldPub),
                     "impl" => self.create_token(TokenKind::Impl),
                     "enum" => self.create_token(TokenKind::Enum),
                     "match" => self.create_token(TokenKind::Match),

--- a/compiler/lex/src/tests.rs
+++ b/compiler/lex/src/tests.rs
@@ -339,3 +339,26 @@ fn byte_literal_escape_sequences() {
     lex_test(r#"b'\\'"#, vec![ByteLiteral(b'\\'), Semi, Eoi]);
     lex_test(r#"b'\''"#, vec![ByteLiteral(b'\''), Semi, Eoi]);
 }
+
+#[test]
+fn fn_and_pub_are_ordinary_identifiers() {
+    lex_test(
+        "fn pub",
+        vec![Ident("fn".to_string()), Ident("pub".to_string()), Semi, Eoi],
+    );
+}
+
+#[test]
+fn fn_and_pub_can_name_a_binding() {
+    lex_test(
+        "let fn = 1",
+        vec![
+            Let,
+            Ident("fn".to_string()),
+            Eq,
+            Int("1".to_string()),
+            Semi,
+            Eoi,
+        ],
+    );
+}

--- a/compiler/lex/src/token.rs
+++ b/compiler/lex/src/token.rs
@@ -107,8 +107,6 @@ pub enum TokenKind {
     // Reserved words
     /// "fun"
     Fun,
-    /// "fn" (reserved old syntax)
-    OldFn,
     /// "return"
     Return,
     /// "let"
@@ -135,8 +133,6 @@ pub enum TokenKind {
     Import,
     /// "export"
     Export,
-    /// "pub" (reserved old syntax)
-    OldPub,
     /// "impl"
     Impl,
     /// "enum"
@@ -235,7 +231,6 @@ impl std::fmt::Display for TokenKind {
                 Tilde => "'~'",
 
                 Fun => "'fun'",
-                OldFn => "'fn'",
                 Return => "'return'",
                 Let => "'let'",
                 Const => "'const'",
@@ -249,7 +244,6 @@ impl std::fmt::Display for TokenKind {
                 Interface => "'interface'",
                 Import => "'import'",
                 Export => "'export'",
-                OldPub => "'pub'",
                 Impl => "'impl'",
                 Enum => "'enum'",
                 Match => "'match'",

--- a/compiler/parse/src/top.rs
+++ b/compiler/parse/src/top.rs
@@ -20,15 +20,6 @@ use crate::{
 
 impl Parser {
     pub fn module_item(&mut self) -> ParseResult<ModuleItem> {
-        if self.check(&TokenKind::OldPub) || self.check(&TokenKind::OldFn) {
-            return Err(ParseError::ExpectedError {
-                expected: "new syntax keyword".to_string(),
-                but: self.first().kind.to_string(),
-                span: self.first().span,
-            }
-            .into());
-        }
-
         if self.is_top_level_decl_start() {
             return Ok(ModuleItem::Decl(self.top_level()?));
         }

--- a/compiler/parse/tests/fn_call_args.rs
+++ b/compiler/parse/tests/fn_call_args.rs
@@ -204,18 +204,6 @@ fn parse_fun_type() -> Result<()> {
 }
 
 #[test]
-fn parse_old_fn_type_is_rejected() -> Result<()> {
-    let mut parser = Parser::new("fn(i32) -> bool", FilePath::from(PathBuf::from("test.kd")));
-
-    let err = parser.ty().expect_err("old fn type must fail");
-    let parse_err = err.downcast::<ParseError>().expect("expected parse error");
-
-    assert!(matches!(parse_err, ParseError::ExpectedError { .. }));
-
-    Ok(())
-}
-
-#[test]
 fn parse_foreign_rust_import() -> Result<()> {
     let mut parser = Parser::new(
         "import rust::example_crate",
@@ -276,33 +264,6 @@ fn parse_export_let_is_rejected() -> Result<()> {
     let mut parser = Parser::new("export let x = 1", FilePath::from(PathBuf::from("test.kd")));
 
     let err = parser.run().expect_err("export let must fail");
-    let parse_err = err.downcast::<ParseError>().expect("expected parse error");
-
-    assert!(matches!(parse_err, ParseError::ExpectedError { .. }));
-
-    Ok(())
-}
-
-#[test]
-fn parse_old_fn_keyword_is_rejected() -> Result<()> {
-    let mut parser = Parser::new("fn legacy() {}", FilePath::from(PathBuf::from("test.kd")));
-
-    let err = parser.run().expect_err("old fn keyword must fail");
-    let parse_err = err.downcast::<ParseError>().expect("expected parse error");
-
-    assert!(matches!(parse_err, ParseError::ExpectedError { .. }));
-
-    Ok(())
-}
-
-#[test]
-fn parse_old_pub_keyword_is_rejected() -> Result<()> {
-    let mut parser = Parser::new(
-        "pub fun current() {}",
-        FilePath::from(PathBuf::from("test.kd")),
-    );
-
-    let err = parser.run().expect_err("old pub keyword must fail");
     let parse_err = err.downcast::<ParseError>().expect("expected parse error");
 
     assert!(matches!(parse_err, ParseError::ExpectedError { .. }));


### PR DESCRIPTION
Refs #407.

## What

`fn` and `pub` have been reserved words since the migration to `fun` / `export` in #218 (closed 2026-04-14) — the lexer emitted `TokenKind::OldFn` / `TokenKind::OldPub` and `module_item` carried a guard rejecting them, so that the error could name the new syntax. Nothing in-tree uses the old forms. This removes the reservation: seven lines across `compiler/lex/src/lib.rs`, `compiler/lex/src/token.rs` and `compiler/parse/src/top.rs`.

`fn` and `pub` now lex as `Ident`, so this compiles and prints `3`:

```kaede
fun work() {
  let fn = 1
  let pub = 2
  println(fn + pub)
}
work()
```

## The tradeoff, measured

This is a deliberate diagnostic regression. Before and after, on the real compiler:

```
fn work() { }        1:1  Expected new syntax keyword but 'fn' found
                  →  1:4  Expected ';' but identifier found

pub fun work() { }   1:1  Expected new syntax keyword but 'pub' found
                  →  1:5  Expected ';' but 'fun' found
```

The span moves off the offending token onto the one after it, and the message stops mentioning that a newer syntax exists — so someone pasting a pre-#218 snippet now gets a message that does not hint at the fix.

#407 lists the alternative: keep the targeted diagnostic without the reserved words, by special-casing `Ident("fn")` / `Ident("pub")` at the point `module_item` fails.

Not taken, and the reason is the project's stage rather than the mechanics. Kaede has not had a formal release, so there are no users to migrate — a shim would be compatibility for syntax nobody is running, and the lexer would acquire another one with every future syntax change. A worse message for someone pasting a pre-release snippet is cheaper than that accumulation.

## Tests

Three tests in `compiler/parse/tests/fn_call_args.rs` guarded the shim and are deleted with it: `parse_old_fn_type_is_rejected`, `parse_old_fn_keyword_is_rejected`, `parse_old_pub_keyword_is_rejected`. Each asserts only that a `ParseError` comes back. With the shim gone, "the old syntax is rejected" is no longer a property the compiler has — `fn legacy() {}` still errors, but incidentally, because `fn` is now an ordinary identifier in a position that wants none. Two of the three kept passing for exactly that reason, which is worse than failing; only `parse_old_fn_type_is_rejected` went red. Rewriting them would move the accommodation into the test suite.

Two lexer tests state the new behaviour positively instead: `fn pub` lexes as two `Ident`s, and `let fn = 1` lexes as a binding.

`cargo fmt --all -- --check` and `cargo clippy -- -D warnings` are clean.

`cargo test --release --no-fail-fast` leaves 13 failures, and **the identical 13 fail on `main`** with this branch stashed — filesystem operations, percent-decoding, a websocket upgrade, and the eight rust-interop tests that shell out to `cargo` to build a shim crate:

```
std_fs_dir_operations_support_temp_rename_sync_and_remove
std_fs_open_options_cover_write_read_append_and_exclusive_create
std_fs_write_atomic_replaces_or_preserves_existing_file
std_http_query_percent_decoding_preserves_utf8
std_http_websocket_upgrade_ping_pong_and_echo_work_with_partial_frames
import_rust_function_with_multiple_str_params
import_rust_function_with_str_and_primitives
import_rust_function_with_str_param
import_rust_function_with_string_param_str_return_and_char
import_rust_function_with_string_return
import_rust_functions_with_primitive_params_and_returns
import_rust_skips_mut_str_param_but_keeps_supported_ones
import_rust_skips_unsupported_pointer_but_keeps_supported_ones
```

Every other test target passes. Note `-p kaede_parse` needs running explicitly to see its result — it did not appear in my first full-suite log at all, which is how the shim test initially went unnoticed.

## Follow-up

`editors/vscode/syntaxes/kaede.tmLanguage.json` scopes `fn` / `pub` as `invalid.illegal.old-syntax.kaede` (added in #403). That rule exists only because the compiler rejects them, so it comes out once this merges — the grammar rule was never load-bearing, and with it gone `fn` simply reads as an ordinary identifier, which is now the accurate rendering.

